### PR TITLE
Updated installation instructions.

### DIFF
--- a/content/starting.tex
+++ b/content/starting.tex
@@ -19,8 +19,8 @@ cabal update; cabal install idris
 \end{lstlisting}
 
 \noindent
-This will install the latest version released on Hackage, along with any dependencies. 
-If, however, you would like the most up to date development version, you can find it on GitHub at: \url{https://github.com/edwinb/Idris-dev}.
+This will install the latest version released on Hackage, along with any dependencies.
+If, however, you would like the most up to date development version you can find it, as well as build intructions, on GitHub at: \url{https://github.com/edwinb/Idris-dev}.
 
 To check that installation has succeeded, and to write your first \Idris{} program, create a file called ``\texttt{hello.idr}'' containing the following text:
 
@@ -28,7 +28,7 @@ To check that installation has succeeded, and to write your first \Idris{} progr
 
 \noindent
 If you are familiar with Haskell, it should be fairly clear what the program is doing and how it works, but if not, we will explain the details later.
-You can compile the program to an executable by entering \texttt{idris hello.idr -o hello} at the shell prompt. 
+You can compile the program to an executable by entering \texttt{idris hello.idr -o hello} at the shell prompt.
 This will create an executable called \texttt{hello}, which you can run:
 
 \begin{lstlisting}[style=stdout]
@@ -38,7 +38,9 @@ Hello world
 \end{lstlisting}
 
 \noindent
-Note that the \texttt{\$} indicates the shell prompt! Some useful options to the \Idris{} command are:
+Note that the \texttt{\$} indicates the shell prompt! 
+Should the \Idris{} executable not be found please ensure that you have added \verb!~/.cabal/bin! to your \verb!$PATH! environment variable.
+Some useful options to the \Idris{} command are:
 
 \begin{itemize}
 \item \texttt{-o prog} to compile to an executable called \texttt{prog}.


### PR DESCRIPTION
Added note on checking that `~/.cabal/bin` was added to `$PATH`. Fixes Issue https://github.com/idris-hackers/idris-tutorial/issues/8
