### PR TITLE
Fix maybe type signature to reflect standard lib

### DIFF
--- a/content/typesfuns.tex
+++ b/content/typesfuns.tex
@@ -560,7 +560,7 @@ For example, looking something up in a \texttt{List} (rather than a vector) may 
 The \texttt{maybe} function is used to process values of type \texttt{Maybe}, either by applying a function to the value, if there is one, or by providing a default value:
 
 \begin{code}
-maybe : |(default:b) -> (a -> b) -> Maybe a -> b
+maybe : Lazy b -> (a -> b) -> Maybe a -> b
 \end{code}
 
 


### PR DESCRIPTION
Correct the type signature example of the maybe function to reflect what is found in the standard Idris librarie.

In the most recent version the vertical bar was replaced by Lazy but I don't know if that should be changed right away.
