### PR TITLE
Fix typo of variable name

### DIFF
--- a/content/classes.tex
+++ b/content/classes.tex
@@ -95,7 +95,7 @@ class Eq a where
     (/=) : a -> a -> Bool
 
     x /= y = not (x == y)
-    y == y = not (x /= y)
+    x == y = not (x /= y)
 \end{code}
 
 \noindent


### PR DESCRIPTION
Minor typo in the default implementation of `Eq.(==)`.
