### PR TITLE
Update MkVects example

### DIFF
--- a/content/modules.tex
+++ b/content/modules.tex
@@ -115,7 +115,7 @@ Parameters blocks can be nested, and can also include data declarations, in whic
 They may also be dependent types with implicit arguments:
 
 \begin{code}
-parameters (xs : Vect x a, y : Nat)
+parameters (y : Nat, xs : Vect x a)
     data Vects : Type -> Type where
          MkVects : Vect y a -> Vects a
   
@@ -128,7 +128,7 @@ To use \texttt{Vects} or \texttt{append} outside the block, we must also give th
 Here, we can use placeholders for the values which can be inferred by the type checker:
 
 \begin{lstlisting}[style=stdout]
-*params> show (append _ _ (MkVects [1,2,3] _ [4,5,6]))
+*params> show (append _ _ (MkVects _ [1,2,3] [4,5,6]))
 "[1, 2, 3, 4, 5, 6]" : String
 \end{lstlisting}
 


### PR DESCRIPTION
Fixed a typo and updated the order of arguments for `MkVects` to match `Vect`.
