### PR TITLE
Add tip about Idris path on OS X

### DIFF
--- a/content/starting.tex
+++ b/content/starting.tex
@@ -40,6 +40,7 @@ Hello world
 \noindent
 Note that the \texttt{\$} indicates the shell prompt!
 Should the \Idris{} executable not be found please ensure that you have added \verb!~/.cabal/bin! to your \verb!$PATH! environment variable.
+Mac OS X users may find they need to use \verb!~/Library/Haskell/bin! instead.
 Some useful options to the \Idris{} command are:
 
 \begin{itemize}


### PR DESCRIPTION
I just started the tutorial on OS X and bumped into a small problem with my Cabal path. Here's a pointer to help anyone else who runs into the same problem.
