### PR TITLE
Fix qsort implementation in totality section

### DIFF
--- a/content/theorems.tex
+++ b/content/theorems.tex
@@ -375,7 +375,7 @@ total
 qsort : Ord a => List a -> List a
 qsort [] = []
 qsort (x :: xs)
-   = qsort (assert_smaller (x :: xs) (filter (<= x) xs)) ++
+   = qsort (assert_smaller (x :: xs) (filter (< x) xs)) ++
       (x :: qsort (assert_smaller (x :: xs) (filter (>= x) xs)))
 \end{code}
 


### PR DESCRIPTION
The current implementation of qsort here double counts instances of x... we should fix that.

On a different note... I feel like in the future we shouldn't need `assert_smaller` here at all, since `xs` is guaranteed to be smaller than `x :: xs` (and filter can never make a list larger).
