### PR TITLE
Fixed float placement for listing in interp.tex.

### DIFF
--- a/content/interp.tex
+++ b/content/interp.tex
@@ -78,7 +78,7 @@ So, in an expression \texttt{$\backslash$x. $\backslash$y. x y},  the variable \
 We find these by counting the number of lambdas between the definition and the use.
 
 \noindent
-A value carries a concrete representation of an integer: 
+A value carries a concrete representation of an integer:
 
 \begin{code}
 Val : (x : Int) -> Expr G TyInt
@@ -103,7 +103,7 @@ App : Expr G (TyFun a t) -> Expr G a -> Expr G t
 We allow arbitrary binary operators, where the type of the operator informs what the types of the arguments must be:
 
 \begin{code}
-Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b -> 
+Op  : (interpTy a -> interpTy b -> interpTy c) -> Expr G a -> Expr G b ->
       Expr G c
 \end{code}
 
@@ -139,7 +139,7 @@ interp env (Val x)     = x
 interp env (Lam sc)    = \x => interp (x :: env) sc
 interp env (App f s)   = interp env f (interp env s)
 interp env (Op op x y) = op (interp env x) (interp env y)
-interp env (If x t e)  = if interp env x then interp env t 
+interp env (If x t e)  = if interp env x then interp env t
                                          else interp env e
 \end{code}
 
@@ -187,7 +187,7 @@ For operators, we apply the function to its operands directly, and for \texttt{I
 
 \begin{code}
 interp env (Op op x y) = op (interp env x) (interp env y)
-interp env (If x t e)  = if interp env x then interp env t 
+interp env (If x t e)  = if interp env x then interp env t
                                          else interp env e
 \end{code}
 
@@ -207,7 +207,7 @@ More interestingly, we can write a factorial function, where
 \begin{code}
 fact : Expr G (TyFun TyInt TyInt)
 fact = Lam (If (Op (==) (Var Stop) (Val 0))
-               (Val 1) (Op (*) (App fact (Op (-) (Var Stop) (Val 1))) 
+               (Val 1) (Op (*) (App fact (Op (-) (Var Stop) (Val 1)))
                                (Var Stop)))
 \end{code}
 
@@ -218,7 +218,7 @@ To finish, we write a \texttt{main} program which interprets the factorial funct
 main : IO ()
 main = do putStr "Enter a number: "
           x <- getLine
-          print (interp [] fact (cast x)) 
+          print (interp [] fact (cast x))
 \end{code}
 
 \noindent
@@ -226,19 +226,19 @@ Here, \texttt{cast} is an overloaded function which converts a value from one ty
 Here, it converts a string to an integer, giving 0 if the input is invalid.
 An example run of this program at the \Idris{} interactive environment is shown in Listing~\ref{factrun}.
 
-\begin{lstlisting}[float=here,caption={Running the well-typed interpreter}, label=factrun, style=stdout]
-$ idris interp.idr  
-     ____    __     _                                          
-    /  _/___/ /____(_)____                                     
+\begin{lstlisting}[float=h,caption={Running the well-typed interpreter}, label=factrun, style=stdout]
+$ idris interp.idr
+     ____    __     _
+    /  _/___/ /____(_)____
     / // __  / ___/ / ___/     Version ^\version{}^
-  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/      
- /___/\__,_/_/  /_/____/       Type :? for help                
+  _/ // /_/ / /  / (__  )      http://www.idris-lang.org/
+ /___/\__,_/_/  /_/____/       Type :? for help
 
 Type checking ./interp.idr
-*interp> :exec 
-Enter a number: 6 
+*interp> :exec
+Enter a number: 6
 720
-*interp> 
+*interp>
 \end{lstlisting}
 
 \subsubsection*{Aside: \texttt{cast}}
@@ -248,7 +248,7 @@ The prelude defines a type class \texttt{Cast} which allows conversion between t
 \begin{code}
 class Cast from to where
     cast : from -> to
-\end{code} 
+\end{code}
 
 \noindent
 It is a \emph{multi-parameter} type class, defining the source type and object type of the cast.
@@ -272,7 +272,7 @@ There are casts defined between all of the primitive types, as far as they make 
 %\begin{code}
 %unitTestFac : so (interp [] fact 4 == 24)
 %unitTestFac = oh
-%\end{code} 
+%\end{code}
 
 %\noindent
 %For the program to compile, the test case must pass. If we change \texttt{24} to \texttt{25}, say, we will get an error message like the following:
@@ -283,5 +283,4 @@ There are casts defined between all of the primitive types, as far as they make 
 
 %Specifically:
 %	 Can't unify True with False
-%\end{lstlisting} 
-
+%\end{lstlisting}


### PR DESCRIPTION
My editor also removes trailing space....but the issue is on L229, the placement option of `here` was changed to `h`.
