### PR TITLE
Added the choose function to the So data type section

### DIFF
--- a/content/typesfuns.tex
+++ b/content/typesfuns.tex
@@ -734,6 +734,17 @@ drawPoint : (x : Int) -> (y : Int) -> So (inBounds x y) -> IO ()
 drawPoint x y p = unsafeDrawPoint x y
 \end{code}
 
+\noindent
+A value of type \texttt{So} can be constructed using the \texttt{choose} function from the prelude.
+The \texttt{choose} function takes a boolean and returns an \texttt{Either (So b) (So (not b))}.
+
+\begin{code}
+safeDrawPoint : Int -> Int -> IO ()
+safeDrawPoint x y = case choose (inBounds x y) of
+                      Left p  => drawPoint x y p
+                      Right p => return ()  -- Handle the error here
+\end{code}
+
 
 \subsection{More Expressions}
 


### PR DESCRIPTION
The tutorial mentions the So datatype as a way to ensure certain runtime tests have been performed but doesn't actually tell the reader how to construct a value of type So (how to convince the type checker that this runtime check has been made). This resolves #40 which I opened a while about about this problem.
